### PR TITLE
fix assert<T>(T?, T -> Bool)

### DIFF
--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -100,7 +100,12 @@ public func failure(message: String, file: String = __FILE__, line: UInt = __LIN
 // MARK: - Implementation details
 
 private func assertPredicate<T>(actual: T?, predicate: T -> Bool, message: String, file: String, line: UInt) -> T? {
-	return actual.map { predicate($0) ? actual : nil } ?? failure(message, file: file, line: line)
+	switch actual {
+	case let .Some(x) where predicate(x):
+		return actual
+	default:
+		return failure(message, file: file, line: line)
+	}
 }
 
 private func assertExpected<T, U>(actual: T?, match: (T, U) -> Bool, expected: U?, message: String, file: String, line: UInt) -> T? {


### PR DESCRIPTION
Fix `assert("foo", { $0.isEmpty })` passes tests.
