### PR TITLE
Throwing

### DIFF
--- a/Assertions.xcodeproj/project.pbxproj
+++ b/Assertions.xcodeproj/project.pbxproj
@@ -277,7 +277,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Rob Rix";
 				TargetAttributes = {
 					D4C2EDE01A98DD7D00054FAA = {
@@ -462,6 +462,7 @@
 				);
 				INFOPLIST_FILE = AssertionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.antitypical.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 			};
@@ -478,6 +479,7 @@
 				);
 				INFOPLIST_FILE = AssertionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.antitypical.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -638,6 +640,7 @@
 				);
 				INFOPLIST_FILE = AssertionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.antitypical.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -653,6 +656,7 @@
 				);
 				INFOPLIST_FILE = AssertionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.antitypical.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Assertions.xcodeproj/xcshareddata/xcschemes/Assertions-Mac.xcscheme
+++ b/Assertions.xcodeproj/xcshareddata/xcschemes/Assertions-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Assertions.xcodeproj/xcshareddata/xcschemes/Assertions-iOS.xcscheme
+++ b/Assertions.xcodeproj/xcshareddata/xcschemes/Assertions-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -50,7 +50,7 @@ public func assertNoThrow<A>(@autoclosure test: () throws -> A, file: String = _
 	do {
 		return try test()
 	} catch {
-		XCTFail("\(error)", file: file, line: line)
+		failure("\(error)", file: file, line: line)
 		return nil
 	}
 }

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -39,22 +39,6 @@ public func assert<T>(@autoclosure expression: () throws -> T?, message: String 
 }
 
 
-// MARK: - Throws
-
-/// Asserts that an expression does not throw an error.
-///
-/// This can be combined with other assertions, enabling convenient testing of equality (or other matchers, see `assert`) without losing error messages:
-///
-///		assert(assertNoThrow(try thingThatMightFail()), ==, successValue)
-public func assertNoThrow<A>(@autoclosure test: () throws -> A, file: String = __FILE__, line: UInt = __LINE__) -> A? {
-	do {
-		return try test()
-	} catch {
-		return failure("\(error)", file: file, line: line)
-	}
-}
-
-
 // MARK: - Equality
 
 /// Asserts the equality of two Equatable values.

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -115,13 +115,17 @@ public func failure(message: String, file: String = __FILE__, line: UInt = __LIN
 
 // MARK: - Implementation details
 
-private func assertPredicate<T>(@noescape actual: () -> T?, _ predicate: T -> Bool, _ message: String, _ file: String, _ line: UInt) -> T? {
-	let actual = actual()
-	switch actual {
-	case let .Some(x) where predicate(x):
-		return actual
-	default:
-		return failure(message, file: file, line: line)
+private func assertPredicate<T>(@noescape actual: () throws -> T?, _ predicate: T -> Bool, _ message: String, _ file: String, _ line: UInt) -> T? {
+	do {
+		let actual = try actual()
+		switch actual {
+		case let .Some(x) where predicate(x):
+			return actual
+		default:
+			return failure(message, file: file, line: line)
+		}
+	} catch {
+		return failure("caught error: '\(error)' \(message)", file: file, line: line)
 	}
 }
 

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -35,7 +35,7 @@ public func assert<T, U>(@autoclosure expression1: () throws -> T?, _ test: T ->
 ///
 ///		assert("", { $0.isEmpty })
 public func assert<T>(@autoclosure expression: () -> T?, message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ test: T -> Bool) -> T? {
-	return assertPredicate(expression(), test, message, file, line)
+	return assertPredicate(expression, test, message, file, line)
 }
 
 
@@ -90,7 +90,7 @@ public func assertNil<T>(@autoclosure expression: () -> T?, _ message: String = 
 
 /// Asserts that a value is not nil.
 public func assertNotNil<T>(@autoclosure expression: () -> T?, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
-	return assertPredicate(expression(), { $0 != nil }, "is nil. " + message, file, line)
+	return assertPredicate(expression, { $0 != nil }, "is nil. " + message, file, line)
 }
 
 
@@ -115,7 +115,8 @@ public func failure(message: String, file: String = __FILE__, line: UInt = __LIN
 
 // MARK: - Implementation details
 
-private func assertPredicate<T>(actual: T?, _ predicate: T -> Bool, _ message: String, _ file: String, _ line: UInt) -> T? {
+private func assertPredicate<T>(@noescape actual: () -> T?, _ predicate: T -> Bool, _ message: String, _ file: String, _ line: UInt) -> T? {
+	let actual = actual()
 	switch actual {
 	case let .Some(x) where predicate(x):
 		return actual

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -7,7 +7,7 @@
 /// This is useful for asserting the equality of collections which only define equality for Equatable element types.
 ///
 ///		assert(x, ==, y)
-public func assert<T>(@autoclosure expression1: () -> T?, _ test: (T, T) -> Bool, @autoclosure _ expression2: () -> T, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
+public func assert<T>(@autoclosure expression1: () throws -> T?, _ test: (T, T) -> Bool, @autoclosure _ expression2: () -> T, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
 	return assertExpected(expression1, test, expression2(), message, file, line)
 }
 
@@ -16,7 +16,7 @@ public func assert<T>(@autoclosure expression1: () -> T?, _ test: (T, T) -> Bool
 /// This is useful for asserting the equality of collections which only define equality for Equatable element types.
 ///
 ///		assert(x, ==, y)
-public func assert<T, U>(@autoclosure expression1: () -> T, _ test: (T, U) -> Bool, @autoclosure _ expression2: () -> U, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
+public func assert<T, U>(@autoclosure expression1: () throws -> T, _ test: (T, U) -> Bool, @autoclosure _ expression2: () -> U, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
 	return assertExpected(expression1, test, expression2(), message, file, line)
 }
 
@@ -25,7 +25,7 @@ public func assert<T, U>(@autoclosure expression1: () -> T, _ test: (T, U) -> Bo
 /// This is useful for asserting that some method applies to the receiver on the left and the operand on the right.
 ///
 ///		assert(Set([ 1, 2, 3 ]), Set.contains, 3)
-public func assert<T, U>(@autoclosure expression1: () -> T?, _ test: T -> U -> Bool, @autoclosure _ expression2: () -> U, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
+public func assert<T, U>(@autoclosure expression1: () throws -> T?, _ test: T -> U -> Bool, @autoclosure _ expression2: () -> U, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
 	return assertExpected(expression1, { x, y in test(x)(y) }, expression2(), message, file, line)
 }
 
@@ -60,7 +60,7 @@ public func assertNoThrow<A>(@autoclosure test: () throws -> A, file: String = _
 /// Asserts the equality of two Equatable values.
 ///
 /// Returns the value, if equal and non-nil.
-public func assertEqual<T: Equatable>(@autoclosure expression1: () -> T?, @autoclosure _ expression2: () -> T?, _ message: String = "", _ file: String = __FILE__, _ line: UInt = __LINE__) -> T? {
+public func assertEqual<T: Equatable>(@autoclosure expression1: () throws -> T?, @autoclosure _ expression2: () -> T?, _ message: String = "", _ file: String = __FILE__, _ line: UInt = __LINE__) -> T? {
 	return assertExpected(expression1, { $0 == $1 }, expression2(), message, file, line)
 }
 
@@ -68,7 +68,7 @@ public func assertEqual<T: Equatable>(@autoclosure expression1: () -> T?, @autoc
 /// Asserts the equality of two arrays of Equatable values.
 ///
 /// Returns the array, if equal and non-nil.
-public func assertEqual<T: Equatable>(@autoclosure expression1: () -> [T]?, @autoclosure _ expression2: () -> [T]?, _ message: String = "", _ file: String = __FILE__, _ line: UInt = __LINE__) -> [T]? {
+public func assertEqual<T: Equatable>(@autoclosure expression1: () throws -> [T]?, @autoclosure _ expression2: () -> [T]?, _ message: String = "", _ file: String = __FILE__, _ line: UInt = __LINE__) -> [T]? {
 	return assertExpected(expression1, ==, expression2(), message, file, line)
 }
 
@@ -76,7 +76,7 @@ public func assertEqual<T: Equatable>(@autoclosure expression1: () -> [T]?, @aut
 /// Asserts the equality of two dictionaries of Equatable values.
 ///
 /// Returns the dictionary, if equal and non-nil.
-public func assertEqual<T: Hashable, U: Equatable>(@autoclosure expression1: () -> [T: U]?, @autoclosure _ expression2: () -> [T: U]?, _ message: String = "", _ file: String = __FILE__, _ line: UInt = __LINE__) -> [T: U]? {
+public func assertEqual<T: Hashable, U: Equatable>(@autoclosure expression1: () throws -> [T: U]?, @autoclosure _ expression2: () -> [T: U]?, _ message: String = "", _ file: String = __FILE__, _ line: UInt = __LINE__) -> [T: U]? {
 	return assertExpected(expression1, ==, expression2(), message, file, line)
 }
 

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -8,7 +8,7 @@
 ///
 ///		assert(x, ==, y)
 public func assert<T>(@autoclosure expression1: () -> T?, _ test: (T, T) -> Bool, @autoclosure _ expression2: () -> T, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
-	return assertExpected(expression1(), test, expression2(), message, file, line)
+	return assertExpected(expression1, test, expression2(), message, file, line)
 }
 
 /// Asserts that a binary function matches two operands.
@@ -17,7 +17,7 @@ public func assert<T>(@autoclosure expression1: () -> T?, _ test: (T, T) -> Bool
 ///
 ///		assert(x, ==, y)
 public func assert<T, U>(@autoclosure expression1: () -> T, _ test: (T, U) -> Bool, @autoclosure _ expression2: () -> U, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
-	return assertExpected(expression1(), test, expression2(), message, file, line)
+	return assertExpected(expression1, test, expression2(), message, file, line)
 }
 
 /// Asserts that a curried binary function matches two operands.
@@ -26,7 +26,7 @@ public func assert<T, U>(@autoclosure expression1: () -> T, _ test: (T, U) -> Bo
 ///
 ///		assert(Set([ 1, 2, 3 ]), Set.contains, 3)
 public func assert<T, U>(@autoclosure expression1: () -> T?, _ test: T -> U -> Bool, @autoclosure _ expression2: () -> U, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
-	return assertExpected(expression1(), { x, y in test(x)(y) }, expression2(), message, file, line)
+	return assertExpected(expression1, { x, y in test(x)(y) }, expression2(), message, file, line)
 }
 
 /// Asserts the truth of a predicate applied to a value.
@@ -62,7 +62,7 @@ public func assertNoThrow<A>(@autoclosure test: () throws -> A, file: String = _
 ///
 /// Returns the value, if equal and non-nil.
 public func assertEqual<T: Equatable>(@autoclosure expression1: () -> T?, @autoclosure _ expression2: () -> T?, _ message: String = "", _ file: String = __FILE__, _ line: UInt = __LINE__) -> T? {
-	return assertExpected(expression1(), { $0 == $1 }, expression2(), message, file, line)
+	return assertExpected(expression1, { $0 == $1 }, expression2(), message, file, line)
 }
 
 
@@ -70,7 +70,7 @@ public func assertEqual<T: Equatable>(@autoclosure expression1: () -> T?, @autoc
 ///
 /// Returns the array, if equal and non-nil.
 public func assertEqual<T: Equatable>(@autoclosure expression1: () -> [T]?, @autoclosure _ expression2: () -> [T]?, _ message: String = "", _ file: String = __FILE__, _ line: UInt = __LINE__) -> [T]? {
-	return assertExpected(expression1(), ==, expression2(), message, file, line)
+	return assertExpected(expression1, ==, expression2(), message, file, line)
 }
 
 
@@ -78,7 +78,7 @@ public func assertEqual<T: Equatable>(@autoclosure expression1: () -> [T]?, @aut
 ///
 /// Returns the dictionary, if equal and non-nil.
 public func assertEqual<T: Hashable, U: Equatable>(@autoclosure expression1: () -> [T: U]?, @autoclosure _ expression2: () -> [T: U]?, _ message: String = "", _ file: String = __FILE__, _ line: UInt = __LINE__) -> [T: U]? {
-	return assertExpected(expression1(), ==, expression2(), message, file, line)
+	return assertExpected(expression1, ==, expression2(), message, file, line)
 }
 
 
@@ -125,7 +125,7 @@ private func assertPredicate<T>(actual: T?, _ predicate: T -> Bool, _ message: S
 	}
 }
 
-private func assertExpected<T, U>(actual: T?, _ match: (T, U) -> Bool, _ expected: U?, _ message: String, _ file: String, _ line: UInt) -> T? {
+private func assertExpected<T, U>(@noescape actual: () -> T?, _ match: (T, U) -> Bool, _ expected: U?, _ message: String, _ file: String, _ line: UInt) -> T? {
 	switch (actual, expected) {
 	case (.None, .None):
 		return actual

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -39,6 +39,18 @@ public func assert<T>(@autoclosure expression: () -> T?, message: String = "", f
 }
 
 
+// MARK: - Throws
+
+public func assertNoThrow<A>(@autoclosure test: () throws -> A, file: String = __FILE__, line: UInt = __LINE__) -> A? {
+	do {
+		return try test()
+	} catch {
+		XCTFail("\(error)", file: file, line: line)
+		return nil
+	}
+}
+
+
 // MARK: - Equality
 
 /// Asserts the equality of two Equatable values.

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -125,18 +125,23 @@ private func assertPredicate<T>(actual: T?, _ predicate: T -> Bool, _ message: S
 	}
 }
 
-private func assertExpected<T, U>(@noescape actual: () -> T?, _ match: (T, U) -> Bool, _ expected: U?, _ message: String, _ file: String, _ line: UInt) -> T? {
-	switch (actual, expected) {
-	case (.None, .None):
-		return actual
-	case let (.Some(x), .Some(y)) where match(x, y):
-		return actual
-	case let (.Some(x), .Some(y)):
-		return failure("\(String(reflecting: x)) did not match \(String(reflecting: y)). " + message, file: file, line: line)
-	case let (.Some(x), .None):
-		return failure("\(String(reflecting: x)) did not match nil. " + message, file: file, line: line)
-	case let (.None, .Some(y)):
-		return failure("nil did not match \(String(reflecting: y)). " + message, file: file, line: line)
+private func assertExpected<T, U>(@noescape actual: () throws -> T?, _ match: (T, U) -> Bool, _ expected: U?, _ message: String, _ file: String, _ line: UInt) -> T? {
+	do {
+		let actual = try actual()
+		switch (actual, expected) {
+		case (.None, .None):
+			return actual
+		case let (.Some(x), .Some(y)) where match(x, y):
+			return actual
+		case let (.Some(x), .Some(y)):
+			return failure("\(String(reflecting: x)) did not match \(String(reflecting: y)). " + message, file: file, line: line)
+		case let (.Some(x), .None):
+			return failure("\(String(reflecting: x)) did not match nil. " + message, file: file, line: line)
+		case let (.None, .Some(y)):
+			return failure("nil did not match \(String(reflecting: y)). " + message, file: file, line: line)
+		}
+	} catch {
+		return failure("caught error: '\(error)' \(message)", file: file, line: line)
 	}
 }
 

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -34,7 +34,7 @@ public func assert<T, U>(@autoclosure expression1: () throws -> T?, _ test: T ->
 /// This is useful for asserting that a value has some property or other.
 ///
 ///		assert("", { $0.isEmpty })
-public func assert<T>(@autoclosure expression: () -> T?, message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ test: T -> Bool) -> T? {
+public func assert<T>(@autoclosure expression: () throws -> T?, message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ test: T -> Bool) -> T? {
 	return assertPredicate(expression, test, message, file, line)
 }
 
@@ -89,7 +89,7 @@ public func assertNil<T>(@autoclosure expression: () -> T?, _ message: String = 
 }
 
 /// Asserts that a value is not nil.
-public func assertNotNil<T>(@autoclosure expression: () -> T?, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
+public func assertNotNil<T>(@autoclosure expression: () throws -> T?, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> T? {
 	return assertPredicate(expression, { $0 != nil }, "is nil. " + message, file, line)
 }
 

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -50,8 +50,7 @@ public func assertNoThrow<A>(@autoclosure test: () throws -> A, file: String = _
 	do {
 		return try test()
 	} catch {
-		failure("\(error)", file: file, line: line)
-		return nil
+		return failure("\(error)", file: file, line: line)
 	}
 }
 

--- a/Assertions/Assertions.swift
+++ b/Assertions/Assertions.swift
@@ -41,6 +41,11 @@ public func assert<T>(@autoclosure expression: () -> T?, message: String = "", f
 
 // MARK: - Throws
 
+/// Asserts that an expression does not throw an error.
+///
+/// This can be combined with other assertions, enabling convenient testing of equality (or other matchers, see `assert`) without losing error messages:
+///
+///		assert(assertNoThrow(try thingThatMightFail()), ==, successValue)
 public func assertNoThrow<A>(@autoclosure test: () throws -> A, file: String = __FILE__, line: UInt = __LINE__) -> A? {
 	do {
 		return try test()

--- a/AssertionsTests/AssertionsTests.swift
+++ b/AssertionsTests/AssertionsTests.swift
@@ -53,6 +53,11 @@ final class AssertionsTests: XCTestCase {
 		}
 	}
 
+	func testAssertingThrowingPropertyWithPredicate() {
+		func getString() throws -> String { return "" }
+		assert(try getString(), { $0.isEmpty })
+	}
+
 
 	func testAssertingNilOfEquatableType() {
 		let x: Int? = nil

--- a/AssertionsTests/AssertionsTests.swift
+++ b/AssertionsTests/AssertionsTests.swift
@@ -18,7 +18,6 @@ final class AssertionsTests: XCTestCase {
 	func testAssertingWithOptionalStrings() {
 		let string: String? = "hello"
 		assert(string, ==, "hello")
-//		XCTAssertEqual(string, "hello") // => error: cannot find an overload for 'XCTAssertEqual' that accepts an argument list of type '(String?, String)'
 	}
 
 	func testAssertingWithOptionalStringsFailure() {

--- a/AssertionsTests/AssertionsTests.swift
+++ b/AssertionsTests/AssertionsTests.swift
@@ -58,6 +58,12 @@ final class AssertionsTests: XCTestCase {
 		assert(try getStringReturns(), ==, "")
 	}
 
+	func testAssertingThrowingMatcherFailure() {
+		assertFailure {
+			assert(try getStringThrows(), ==, "")
+		}
+	}
+
 	func testAssertingThrowingPropertyWithPredicate() {
 		assert(try getStringReturns(), { $0.isEmpty })
 	}

--- a/AssertionsTests/AssertionsTests.swift
+++ b/AssertionsTests/AssertionsTests.swift
@@ -58,6 +58,13 @@ final class AssertionsTests: XCTestCase {
 		assert(try getString(), { $0.isEmpty })
 	}
 
+	func testAssertingThrowingPropertyWithPredicateFailure() {
+		func getString() throws -> String { throw NSError(domain: "com.antitypical.Assertions", code: -1, userInfo: [:]) }
+		assertFailure {
+			assert(try getString(), { $0.isEmpty })
+		}
+	}
+
 
 	func testAssertingNilOfEquatableType() {
 		let x: Int? = nil

--- a/AssertionsTests/AssertionsTests.swift
+++ b/AssertionsTests/AssertionsTests.swift
@@ -85,16 +85,20 @@ final class AssertionsTests: XCTestCase {
 	// MARK: Testing assertion failures
 
 	/// Assert that `test` causes an assertion failure.
-	func assertFailure<T>(file: String = __FILE__, line: UInt = __LINE__, @noescape _ test: () -> T) -> (message: String, file: String, line: UInt, expected: Bool)? {
-		let previous = expectFailure
-		expectFailure = true
-		test()
-		expectFailure = previous
-		if let result = failure {
-			return result
-		} else {
-			XCTFail("expected the assertion to fail", file: file, line: line)
-			return nil
+	func assertFailure<T>(file: String = __FILE__, line: UInt = __LINE__, @noescape _ test: () throws -> T) -> (message: String, file: String, line: UInt, expected: Bool)? {
+		do {
+			let previous = expectFailure
+			expectFailure = true
+			try test()
+			expectFailure = previous
+			if let result = failure {
+				return result
+			} else {
+				XCTFail("expected the assertion to fail", file: file, line: line)
+				return nil
+			}
+		} catch {
+			return Assertions.failure("error: \(error)", file: file, line: line)
 		}
 	}
 

--- a/AssertionsTests/AssertionsTests.swift
+++ b/AssertionsTests/AssertionsTests.swift
@@ -53,6 +53,11 @@ final class AssertionsTests: XCTestCase {
 		}
 	}
 
+
+	func testAssertingThrowingMatcher() {
+		assert(try getStringReturns(), ==, "")
+	}
+
 	func testAssertingThrowingPropertyWithPredicate() {
 		assert(try getStringReturns(), { $0.isEmpty })
 	}

--- a/AssertionsTests/AssertionsTests.swift
+++ b/AssertionsTests/AssertionsTests.swift
@@ -89,6 +89,17 @@ final class AssertionsTests: XCTestCase {
 	}
 
 
+	// MARK: Throwing functions
+
+	private func getStringReturns() throws -> String {
+		return ""
+	}
+
+	private func getStringThrows() throws -> String {
+		throw NSError(domain: "com.antitypical.Assertions", code: -1, userInfo: [:])
+	}
+
+
 	// MARK: Testing assertion failures
 
 	/// Assert that `test` causes an assertion failure.

--- a/AssertionsTests/AssertionsTests.swift
+++ b/AssertionsTests/AssertionsTests.swift
@@ -54,14 +54,12 @@ final class AssertionsTests: XCTestCase {
 	}
 
 	func testAssertingThrowingPropertyWithPredicate() {
-		func getString() throws -> String { return "" }
-		assert(try getString(), { $0.isEmpty })
+		assert(try getStringReturns(), { $0.isEmpty })
 	}
 
 	func testAssertingThrowingPropertyWithPredicateFailure() {
-		func getString() throws -> String { throw NSError(domain: "com.antitypical.Assertions", code: -1, userInfo: [:]) }
 		assertFailure {
-			assert(try getString(), { $0.isEmpty })
+			assert(try getStringThrows(), { $0.isEmpty })
 		}
 	}
 

--- a/AssertionsTests/AssertionsTests.swift
+++ b/AssertionsTests/AssertionsTests.swift
@@ -94,8 +94,7 @@ final class AssertionsTests: XCTestCase {
 			if let result = failure {
 				return result
 			} else {
-				XCTFail("expected the assertion to fail", file: file, line: line)
-				return nil
+				return Assertions.failure("expected the assertion to fail", file: file, line: line)
 			}
 		} catch {
 			return Assertions.failure("error: \(error)", file: file, line: line)

--- a/AssertionsTests/Info.plist
+++ b/AssertionsTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.antitypical.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
This PR allows expressions which `throw` to occur within the subject value of assertions. Thrown errors will fail assertions, and are logged.
